### PR TITLE
Fix Docker APT source and allow pCloud prompts without stdin

### DIFF
--- a/installer/deps.py
+++ b/installer/deps.py
@@ -56,6 +56,19 @@ def apt(args: list[str], retries: int | None = None) -> None:
 
 def install_prereqs() -> None:
     say("Installing prerequisites…")
+
+    # Some hosts may have an existing Docker APT source configured. If the
+    # file is malformed (for example from a prior manual installation), the
+    # initial ``apt-get update`` would fail before we get a chance to
+    # reconfigure Docker properly.  Removing the list upfront ensures the
+    # update succeeds and we can install Docker later with a clean source.
+    from pathlib import Path
+
+    docker_list = Path("/etc/apt/sources.list.d/docker.list")
+    if docker_list.exists():
+        warn("Removing existing Docker apt source to avoid malformed entry")
+        docker_list.unlink()
+
     apt(["update", "-y"])
     apt(["upgrade", "-y"])
     apt([

--- a/installer/pcloud.py
+++ b/installer/pcloud.py
@@ -6,6 +6,18 @@ import subprocess
 
 from .common import say, warn, ok
 
+try:
+    TTY = open("/dev/tty")
+except OSError:
+    TTY = None
+
+
+def _prompt(text: str) -> str:
+    if TTY is None:
+        return ""
+    print(text, end="", flush=True)
+    return TTY.readline().strip()
+
 RCLONE_REMOTE_NAME = os.environ.get("RCLONE_REMOTE_NAME", "pcloud")
 
 
@@ -111,6 +123,10 @@ def ensure_pcloud_remote_or_menu() -> None:
         ok(f"pCloud remote '{RCLONE_REMOTE_NAME}:' is ready.")
         return
 
+    if TTY is None:
+        warn("No interactive TTY; skipping pCloud configuration for now.")
+        return
+
     while True:
         print()
         say("Choose how to connect to pCloud:")
@@ -118,11 +134,11 @@ def ensure_pcloud_remote_or_menu() -> None:
         print("  2) Headless OAuth helper")
         print("  3) Try legacy WebDAV")
         print("  4) Skip")
-        choice = input("Choose [1-4] [1]: ").strip() or "1"
+        choice = _prompt("Choose [1-4] [1]: ") or "1"
 
         if choice in {"1", "2"}:
             say('On any machine with a browser, run:  rclone authorize "pcloud"')
-            token = _sanitize_oneline(input("Paste token JSON here: "))
+            token = _sanitize_oneline(_prompt("Paste token JSON here: "))
             if not token:
                 warn("Empty token.")
                 continue
@@ -136,13 +152,13 @@ def ensure_pcloud_remote_or_menu() -> None:
             warn("Token invalid or not valid for either region. Try again.")
 
         elif choice == "3":
-            email = input("pCloud login email: ").strip()
+            email = _prompt("pCloud login email: ").strip()
             if not email:
                 warn("Email required.")
                 continue
             import getpass
 
-            password = getpass.getpass("pCloud password (or App Password): ")
+            password = getpass.getpass("pCloud password (or App Password): ", stream=TTY)
             if not password:
                 warn("Password required.")
                 continue


### PR DESCRIPTION
## Summary
- remove existing docker apt source before installing prerequisites to avoid malformed entry failures
- read pCloud configuration prompts from `/dev/tty` so piped installs don't error when stdin is unavailable

## Testing
- `python -m py_compile installer/pcloud.py`
- `python -m py_compile install.py`
- `python -m py_compile installer/deps.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6d2abcf408326b20728ac3a39cca8