### PR TITLE
Fix Docker APT source and read prompts from tty when stdin missing

### DIFF
--- a/installer/files.py
+++ b/installer/files.py
@@ -113,7 +113,7 @@ def write_compose_file() -> None:
                   PAPERLESS_DBPASS: {cfg.postgres_password}
                   PAPERLESS_ADMIN_USER: {cfg.paperless_admin_user}
                   PAPERLESS_ADMIN_PASSWORD: {cfg.paperless_admin_password}
-                  PAPERLESS_URL: ${PAPERLESS_URL}
+                  PAPERLESS_URL: ${{PAPERLESS_URL}}
                   PAPERLESS_TIKA_ENABLED: "1"
                   PAPERLESS_TIKA_GOTENBERG_ENDPOINT: http://gotenberg:3000
                   PAPERLESS_TIKA_ENDPOINT: http://tika:9998
@@ -209,7 +209,7 @@ def write_compose_file() -> None:
                   PAPERLESS_DBPASS: {cfg.postgres_password}
                   PAPERLESS_ADMIN_USER: {cfg.paperless_admin_user}
                   PAPERLESS_ADMIN_PASSWORD: {cfg.paperless_admin_password}
-                  PAPERLESS_URL: ${PAPERLESS_URL}
+                  PAPERLESS_URL: ${{PAPERLESS_URL}}
                   PAPERLESS_TIKA_ENABLED: "1"
                   PAPERLESS_TIKA_GOTENBERG_ENDPOINT: http://gotenberg:3000
                   PAPERLESS_TIKA_ENDPOINT: http://tika:9998


### PR DESCRIPTION
## Summary
- remove existing docker apt source before installing prerequisites to avoid malformed entry failures
- read configuration prompts from `/dev/tty` so piped installs don't crash when stdin is unavailable
- escape `PAPERLESS_URL` placeholder in docker compose template to avoid runtime NameError

## Testing
- `python -m py_compile install.py installer/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6d2abcf408326b20728ac3a39cca8