### PR TITLE
Fix Docker APT source and read prompts from tty when stdin missing

### DIFF
--- a/installer/deps.py
+++ b/installer/deps.py
@@ -56,6 +56,19 @@ def apt(args: list[str], retries: int | None = None) -> None:
 
 def install_prereqs() -> None:
     say("Installing prerequisites…")
+
+    # Some hosts may have an existing Docker APT source configured. If the
+    # file is malformed (for example from a prior manual installation), the
+    # initial ``apt-get update`` would fail before we get a chance to
+    # reconfigure Docker properly.  Removing the list upfront ensures the
+    # update succeeds and we can install Docker later with a clean source.
+    from pathlib import Path
+
+    docker_list = Path("/etc/apt/sources.list.d/docker.list")
+    if docker_list.exists():
+        warn("Removing existing Docker apt source to avoid malformed entry")
+        docker_list.unlink()
+
     apt(["update", "-y"])
     apt(["upgrade", "-y"])
     apt([

--- a/installer/files.py
+++ b/installer/files.py
@@ -7,8 +7,8 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 
 
 def copy_helper_scripts() -> None:
-    """Copy backup and restore helpers into the stack directory."""
-    log("Copying backup and restore helpers")
+    """Copy helper scripts and install bulletproof CLI."""
+    log("Copying helper scripts and installing CLI")
     for name in ("backup.py", "restore.py"):
         src = BASE_DIR / "modules" / name
         dst = Path(cfg.stack_dir) / name
@@ -17,6 +17,14 @@ def copy_helper_scripts() -> None:
             dst.chmod(0o755)
         else:
             warn(f"Missing helper script: {src}")
+
+    bp_src = BASE_DIR / "tools" / "bulletproof.py"
+    bp_dst = Path("/usr/local/bin/bulletproof")
+    if bp_src.exists():
+        bp_dst.write_text(bp_src.read_text())
+        bp_dst.chmod(0o755)
+    else:
+        warn(f"Missing bulletproof CLI: {bp_src}")
 
 
 def write_env_file() -> None:
@@ -113,7 +121,7 @@ def write_compose_file() -> None:
                   PAPERLESS_DBPASS: {cfg.postgres_password}
                   PAPERLESS_ADMIN_USER: {cfg.paperless_admin_user}
                   PAPERLESS_ADMIN_PASSWORD: {cfg.paperless_admin_password}
-                  PAPERLESS_URL: ${PAPERLESS_URL}
+                  PAPERLESS_URL: ${{PAPERLESS_URL}}
                   PAPERLESS_TIKA_ENABLED: "1"
                   PAPERLESS_TIKA_GOTENBERG_ENDPOINT: http://gotenberg:3000
                   PAPERLESS_TIKA_ENDPOINT: http://tika:9998
@@ -209,7 +217,7 @@ def write_compose_file() -> None:
                   PAPERLESS_DBPASS: {cfg.postgres_password}
                   PAPERLESS_ADMIN_USER: {cfg.paperless_admin_user}
                   PAPERLESS_ADMIN_PASSWORD: {cfg.paperless_admin_password}
-                  PAPERLESS_URL: ${PAPERLESS_URL}
+                  PAPERLESS_URL: ${{PAPERLESS_URL}}
                   PAPERLESS_TIKA_ENABLED: "1"
                   PAPERLESS_TIKA_GOTENBERG_ENDPOINT: http://gotenberg:3000
                   PAPERLESS_TIKA_ENDPOINT: http://tika:9998

--- a/modules/backup.py
+++ b/modules/backup.py
@@ -9,8 +9,17 @@ import time
 from pathlib import Path
 from datetime import datetime
 
-sys.path.append(str(Path(__file__).resolve().parent.parent))
-from utils.env import load_env
+
+def load_env(path: Path) -> None:
+    """Load environment variables from a .env file if present."""
+    if not path.exists():
+        return
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        k, v = line.split("=", 1)
+        os.environ.setdefault(k, v)
 
 COLOR_BLUE = "\033[1;34m"
 COLOR_GREEN = "\033[1;32m"

--- a/modules/restore.py
+++ b/modules/restore.py
@@ -8,9 +8,57 @@ import subprocess
 import time
 from pathlib import Path
 
-sys.path.append(str(Path(__file__).resolve().parent.parent))
-from utils.env import load_env
-from utils.selftest import run_stack_tests
+
+def load_env(path: Path) -> None:
+    """Load environment variables from a .env file if present."""
+    if not path.exists():
+        return
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        k, v = line.split("=", 1)
+        os.environ.setdefault(k, v)
+
+
+def run_stack_tests(compose_file: Path, env_file: Path) -> bool:
+    ok = True
+    try:
+        subprocess.run(
+            [
+                "docker",
+                "compose",
+                "--env-file",
+                str(env_file),
+                "-f",
+                str(compose_file),
+                "ps",
+            ],
+            check=True,
+        )
+    except Exception:
+        ok = False
+    try:
+        subprocess.run(
+            [
+                "docker",
+                "compose",
+                "--env-file",
+                str(env_file),
+                "-f",
+                str(compose_file),
+                "exec",
+                "-T",
+                "paperless",
+                "python",
+                "manage.py",
+                "check",
+            ],
+            check=True,
+        )
+    except Exception:
+        ok = False
+    return ok
 
 COLOR_BLUE = "\033[1;34m"
 COLOR_GREEN = "\033[1;32m"


### PR DESCRIPTION
## Summary
- remove existing docker apt source before installing prerequisites to avoid malformed entry failures
- read configuration prompts from `/dev/tty` so piped installs don't crash when stdin is unavailable
- escape `PAPERLESS_URL` placeholder in docker compose template to avoid runtime NameError
- install `bulletproof` CLI during setup and embed `.env` loader so the script works standalone
- embed env loader and self-test logic directly into backup and restore helpers so they run without repository modules
- restore an interactive menu in the `bulletproof` CLI for easier manual use

## Testing
- `python -m py_compile install.py installer/*.py modules/backup.py modules/restore.py tools/bulletproof.py`
- `python tools/bulletproof.py --help`
- `python tools/bulletproof.py` *(exited after showing menu)*

------
https://chatgpt.com/codex/tasks/task_e_68b6d2abcf408326b20728ac3a39cca8