### PR TITLE
Implement weekly full and daily incremental backups

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,19 +153,19 @@ Then it runs: `docker compose up -d` and performs a quick self-test
 
 ## Backup & snapshots
 
-Nightly cron (configurable) runs `backup.py auto` and uploads incrementals to pCloud:
+Nightly cron (configurable) runs `backup.py auto` and uploads to pCloud:
 - Remote: `pcloud:backups/paperless/${INSTANCE_NAME}`
 - Snapshot naming: `YYYYMMDD-HHMMSS`
-- Monthly snapshots are **full**; weekly/daily contain only changed files and point to their parent in `manifest.yaml`
+- Weekly snapshots are **full**; other days are incremental and chain to the last full
 - Includes:
   - Encrypted `.env` (if enabled) or plain `.env`
   - `compose.snapshot.yml` (set `INCLUDE_COMPOSE_IN_BACKUP=no` to skip)
   - Tarballs of `media`, `data`, `export` (incremental)
   - Postgres SQL dump
   - Paperless-NGX version
-  - `manifest.yaml` with versions, file sizes + SHA-256 checksums, host info, retention class, mode & parent
+  - `manifest.yaml` with versions, file sizes + SHA-256 checksums, host info, mode & parent
   - Integrity checks: archives are listed and the DB dump is test-restored; a `status.ok`/`status.fail` file records the result
-- Retention: keep last **N** days (configurable) and tag snapshots as **daily**, **weekly**, or **monthly** (auto by date)
+- Retention: keep last **N** days (configurable)
 
 You can also trigger a backup manually (see **Bulletproof CLI**).
 
@@ -199,7 +199,7 @@ A tiny helper wrapped around the installed scripts.
 
 ```bash
 bulletproof          # interactive menu
-bulletproof backup [class]   # run a snapshot now (daily|weekly|monthly|auto|full)
+bulletproof backup [mode]    # run a backup now (full|incr|auto)
 bulletproof list     # list snapshot folders on pCloud
 bulletproof manifest # show manifest for a snapshot
 bulletproof restore  # guided restore (choose snapshot)
@@ -207,6 +207,7 @@ bulletproof upgrade  # backup + pull images + up -d with rollback
 bulletproof status   # container & health overview
 bulletproof logs     # tail paperless logs
 bulletproof doctor   # quick checks (disk, rclone, DNS/HTTP)
+bulletproof schedule [cron]  # adjust daily backup time
 ```
 
 **Upgrade** runs a backup, pulls new images, restarts the stack, and rolls back automatically if the health check fails.

--- a/install.py
+++ b/install.py
@@ -35,34 +35,25 @@ def _bootstrap() -> None:
 
 
 try:  # first attempt to import locally present modules
-    from installer.common import (
-        cfg,
-        say,
-        need_root,
-        ensure_dir_tree,
-        preflight_ubuntu,
-        prompt_core_values,
-        pick_and_merge_preset,
-        ok,
-        warn,
-    )
-    from installer import deps, files, pcloud
+    from installer import common, deps, files, pcloud
     from utils.selftest import run_stack_tests
 except ModuleNotFoundError:
     _bootstrap()
-    from installer.common import (
-        cfg,
-        say,
-        need_root,
-        ensure_dir_tree,
-        preflight_ubuntu,
-        prompt_core_values,
-        pick_and_merge_preset,
-        ok,
-        warn,
-    )
-    from installer import deps, files, pcloud
+    from installer import common, deps, files, pcloud
     from utils.selftest import run_stack_tests
+
+cfg = common.cfg
+say = common.say
+need_root = common.need_root
+ensure_dir_tree = common.ensure_dir_tree
+preflight_ubuntu = common.preflight_ubuntu
+prompt_core_values = common.prompt_core_values
+pick_and_merge_preset = common.pick_and_merge_preset
+ok = common.ok
+warn = common.warn
+# ``prompt_backup_plan`` was added in newer releases; fall back to a no-op if
+# running against an older checkout that lacks it.
+prompt_backup_plan = getattr(common, "prompt_backup_plan", lambda: None)
 
 
 def main() -> None:
@@ -78,11 +69,25 @@ def main() -> None:
     # pCloud
     pcloud.ensure_pcloud_remote_or_menu()
 
+    ensure_dir_tree(cfg)
+    restore_existing_backup_if_present = getattr(
+        files, "restore_existing_backup_if_present", lambda: False
+    )
+    if restore_existing_backup_if_present():
+        if Path(cfg.env_file).exists():
+            for line in Path(cfg.env_file).read_text().splitlines():
+                if line.startswith("CRON_TIME="):
+                    cfg.cron_time = line.split("=", 1)[1].strip()
+        files.install_cron_backup()
+        files.show_status()
+        return
+
     # Presets and prompts
     pick_and_merge_preset(
         f"https://raw.githubusercontent.com/obidose/obidose-paperless-ngx-bulletproof/{BRANCH}"
     )
     prompt_core_values()
+    prompt_backup_plan()
 
     # Directories and files
     ensure_dir_tree(cfg)

--- a/installer/common.py
+++ b/installer/common.py
@@ -175,6 +175,11 @@ def prompt_core_values() -> None:
     cfg.refresh_paths()
 
 
+def prompt_backup_plan() -> None:
+    print()
+    say("Configure backup schedule")
+    cfg.cron_time = prompt("Daily backup cron time", cfg.cron_time)
+
 
 def pick_and_merge_preset(base: str) -> None:
     print()

--- a/modules/backup.py
+++ b/modules/backup.py
@@ -2,12 +2,23 @@
 """Snapshot Paperless-ngx data and upload to an rclone remote."""
 import os
 import sys
-import tarfile
 import tempfile
 import subprocess
 import time
 from pathlib import Path
 from datetime import datetime
+
+
+def list_snapshots() -> list[str]:
+    res = subprocess.run(
+        ["rclone", "lsd", REMOTE], capture_output=True, text=True, check=False
+    )
+    snaps = []
+    for line in res.stdout.splitlines():
+        parts = line.strip().split()
+        if parts:
+            snaps.append(parts[-1].rstrip("/"))
+    return sorted(snaps)
 
 
 def load_env(path: Path) -> None:
@@ -98,13 +109,27 @@ def dump_db(work: Path) -> None:
         warn("Compose file not found; skipping DB dump")
 
 
-def tar_dir(src: Path, name: str, work: Path) -> None:
+def tar_dir(src: Path, name: str, work: Path, mode: str) -> None:
     if not src.exists():
         warn(f"Skip {name}: directory not found at {src}")
         return
     say(f"Archiving {name}…")
-    with tarfile.open(work / f"{name}.tar.gz", "w:gz") as tar:
-        tar.add(src, arcname=name)
+    snarf = work / f"{name}.snar"
+    if mode == "full" and snarf.exists():
+        snarf.unlink()
+    subprocess.run(
+        [
+            "tar",
+            "--listed-incremental",
+            str(snarf),
+            "-czf",
+            str(work / f"{name}.tar.gz"),
+            "-C",
+            str(src.parent),
+            name,
+        ],
+        check=True,
+    )
 
 
 def verify_archives(work: Path) -> bool:
@@ -157,16 +182,32 @@ def test_db_restore(work: Path) -> bool:
 
 
 def main() -> None:
-    retention_class = sys.argv[1] if len(sys.argv) > 1 else "auto"
+    mode = sys.argv[1] if len(sys.argv) > 1 else "auto"
+    if mode not in {"full", "incr", "auto"}:
+        die("Usage: backup.py [full|incr|auto]")
     ensure_remote_path(REMOTE)
+    snaps = list_snapshots()
+    parent = snaps[-1] if snaps else ""
+    if mode == "auto":
+        if not snaps or datetime.utcnow().weekday() == 6:
+            mode = "full"
+        else:
+            mode = "incr"
+    if mode == "incr" and not snaps:
+        mode = "full"
     snap = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
     work = Path(tempfile.mkdtemp(prefix="paperless-backup."))
-    say(f"Creating snapshot {snap}")
+    if mode == "incr" and parent:
+        subprocess.run(
+            ["rclone", "copy", f"{REMOTE}/{parent}", str(work), "--include", "*.snar"],
+            check=False,
+        )
+    say(f"Creating {mode} snapshot {snap}")
 
     dump_db(work)
-    tar_dir(DIR_MEDIA, "media", work)
-    tar_dir(DIR_DATA, "data", work)
-    tar_dir(DIR_EXPORT, "export", work)
+    tar_dir(DIR_MEDIA, "media", work, mode)
+    tar_dir(DIR_DATA, "data", work, mode)
+    tar_dir(DIR_EXPORT, "export", work, mode)
 
     if ENV_FILE.exists():
         (work / ".env").write_text(ENV_FILE.read_text())
@@ -177,9 +218,10 @@ def main() -> None:
         shutil_path = work / "compose.snapshot.yml"
         shutil_path.write_text(COMPOSE_FILE.read_text())
 
-    (work / "manifest.yaml").write_text(
-        f"mode: full\nretention: {retention_class}\ncreated: {datetime.utcnow().isoformat()}\n"
-    )
+    manifest_lines = [f"mode: {mode}", f"created: {datetime.utcnow().isoformat()}"]
+    if mode == "incr" and parent:
+        manifest_lines.append(f"parent: {parent}")
+    (work / "manifest.yaml").write_text("\n".join(manifest_lines) + "\n")
 
     passed = verify_archives(work) and test_db_restore(work)
     status = "status.ok" if passed else "status.fail"


### PR DESCRIPTION
## Summary
- Switch backups to weekly full and daily incremental snapshots
- Add early restore detection and backup schedule prompts during install
- Extend `bulletproof` CLI with full/incremental modes and cron schedule management
- Handle missing backup prompt gracefully when bootstrapping installer
- Guard backup restore helper against remote listing failures
- Tolerate missing restore helper when bootstrapping against older checkouts

## Testing
- `python -m py_compile modules/backup.py modules/restore.py tools/bulletproof.py install.py installer/common.py installer/files.py`


------
https://chatgpt.com/codex/tasks/task_e_68b80f2b160c8326ba28508d5d034a1a