### PR TITLE
Simplify backup CLI and schedule daily full/hourly incremental backups

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,11 @@ A one‑shot, “batteries‑included” setup for **Paperless‑ngx** on Ubuntu
 
 ## Quick start
 
-The installer pulls code from the `main` branch by default. Set `BP_BRANCH` to a
-branch name or commit SHA to test other versions. The installer uses this value
-for the repository tarball and any preset files, so everything comes from the
-same branch.
+The installer pulls code from the `main` branch by default. Provide a branch
+name or commit SHA with the `--branch` flag (or `BP_BRANCH` environment
+variable) to test other versions. The installer uses this value for the
+repository tarball and any preset files, so everything comes from the same
+branch.
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/obidose/obidose-paperless-ngx-bulletproof/main/install.py | sudo python3 -
@@ -67,12 +68,10 @@ curl -fsSL https://raw.githubusercontent.com/obidose/obidose-paperless-ngx-bulle
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/obidose/obidose-paperless-ngx-bulletproof/dev/install.py \
-  | BP_BRANCH=dev sudo python3 -
+  | BP_BRANCH=dev sudo -E python3 - --branch dev
 ```
 
-The `curl` path ensures you're running the installer from `dev`. The `BP_BRANCH`
-environment variable tells the script to fetch the rest of the code and presets
-from `dev` as well, letting you test changes without touching `main`.
+The env var and flag ensure everything comes from `dev`.
 
 The installer will:
 1. Install/upgrade Docker, rclone, and prerequisites
@@ -84,13 +83,15 @@ The installer will:
 
 > If you ever need to refresh the CLI manually:
 > ```bash
-> curl -fsSL https://raw.githubusercontent.com/obidose/obidose-paperless-ngx-bulletproof/${BP_BRANCH:-main}/tools/bulletproof.py \
->   -o /usr/local/bin/bulletproof && chmod +x /usr/local/bin/bulletproof
+> BRANCH=${BRANCH:-main}
+> curl -fsSL https://raw.githubusercontent.com/obidose/obidose-paperless-ngx-bulletproof/$BRANCH/tools/bulletproof.py \
+>   | sudo tee /usr/local/bin/bulletproof >/dev/null && sudo chmod +x /usr/local/bin/bulletproof
 > ```
 
-Use the same `BP_BRANCH` value when refreshing the CLI so it matches the version
+Use the same `BRANCH` value when refreshing the CLI so it matches the version
 you're testing. After verifying your changes on a VPS, merge them into `main`
-(or tag a release) and run the installer without `BP_BRANCH` for production.
+(or tag a release) and run the installer without specifying a branch for
+production.
 
 ---
 
@@ -153,21 +154,27 @@ Then it runs: `docker compose up -d` and performs a quick self-test
 
 ## Backup & snapshots
 
-Nightly cron (configurable) runs `backup.py auto` and uploads incrementals to pCloud:
+Automated cron jobs upload snapshots to pCloud:
+- **Daily full** backup at a scheduled time
+- **Hourly incremental** backups chaining to the last full
 - Remote: `pcloud:backups/paperless/${INSTANCE_NAME}`
-- Snapshot naming: `YYYYMMDD-HHMMSS`
-- Monthly snapshots are **full**; weekly/daily contain only changed files and point to their parent in `manifest.yaml`
+ - Snapshot naming: `YYYY-MM-DD_HH-MM-SS`
+ - Full snapshots are self-contained; incrementals reference their parent
 - Includes:
   - Encrypted `.env` (if enabled) or plain `.env`
   - `compose.snapshot.yml` (set `INCLUDE_COMPOSE_IN_BACKUP=no` to skip)
   - Tarballs of `media`, `data`, `export` (incremental)
   - Postgres SQL dump
   - Paperless-NGX version
-  - `manifest.yaml` with versions, file sizes + SHA-256 checksums, host info, retention class, mode & parent
+  - `manifest.yaml` with versions, file sizes + SHA-256 checksums, host info, mode & parent
   - Integrity checks: archives are listed and the DB dump is test-restored; a `status.ok`/`status.fail` file records the result
-- Retention: keep last **N** days (configurable) and tag snapshots as **daily**, **weekly**, or **monthly** (auto by date)
+- Retention: keep last **N** days (configurable)
 
 You can also trigger a backup manually (see **Bulletproof CLI**).
+
+During installation you're guided through setting the full backup time (HH:MM)
+and how often incrementals run (hours). Adjust these later with
+`bulletproof schedule`.
 
 ---
 
@@ -199,14 +206,14 @@ A tiny helper wrapped around the installed scripts.
 
 ```bash
 bulletproof          # interactive menu
-bulletproof backup [class]   # run a snapshot now (daily|weekly|monthly|auto|full)
-bulletproof list     # list snapshot folders on pCloud
-bulletproof manifest # show manifest for a snapshot
+bulletproof backup [mode]    # run a backup now (full|incr)
+bulletproof snapshots            # list snapshots (pick number to show manifest)
 bulletproof restore  # guided restore (choose snapshot)
 bulletproof upgrade  # backup + pull images + up -d with rollback
 bulletproof status   # container & health overview
 bulletproof logs     # tail paperless logs
 bulletproof doctor   # quick checks (disk, rclone, DNS/HTTP)
+bulletproof schedule [--full CRON] [--incr CRON]  # adjust backup times
 ```
 
 **Upgrade** runs a backup, pulls new images, restarts the stack, and rolls back automatically if the health check fails.
@@ -235,8 +242,8 @@ bulletproof doctor   # quick checks (disk, rclone, DNS/HTTP)
 - **HTTPS not issuing**  
   Confirm DNS points to this host and ports 80/443 are reachable. Traefik will retry challenges.
 
-- **Backup shows “No snapshots found”**  
-  Run `bulletproof backup` then `bulletproof list`. Verify the path shown matches
+- **Backup shows “No snapshots found”**
+  Run `bulletproof backup` then `bulletproof snapshots`. Verify the path shown matches
   `pcloud:backups/paperless/${INSTANCE_NAME}`. Check rclone with `rclone about pcloud:`.
 
 - **Running without root**  

--- a/install.py
+++ b/install.py
@@ -7,9 +7,19 @@ repository so the full installer can run without a prior ``git clone``.
 
 from pathlib import Path
 import os
+import argparse
+import sys
 
 
-BRANCH = os.environ.get("BP_BRANCH", "main")
+def _parse_branch() -> str:
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--branch")
+    args, unknown = parser.parse_known_args()
+    sys.argv[1:] = unknown
+    return args.branch or os.environ.get("BP_BRANCH", "main")
+
+
+BRANCH = _parse_branch()
 
 
 def _bootstrap() -> None:
@@ -35,38 +45,30 @@ def _bootstrap() -> None:
 
 
 try:  # first attempt to import locally present modules
-    from installer.common import (
-        cfg,
-        say,
-        need_root,
-        ensure_dir_tree,
-        preflight_ubuntu,
-        prompt_core_values,
-        pick_and_merge_preset,
-        ok,
-        warn,
-    )
-    from installer import deps, files, pcloud
+    from installer import common, deps, files, pcloud
     from utils.selftest import run_stack_tests
 except ModuleNotFoundError:
     _bootstrap()
-    from installer.common import (
-        cfg,
-        say,
-        need_root,
-        ensure_dir_tree,
-        preflight_ubuntu,
-        prompt_core_values,
-        pick_and_merge_preset,
-        ok,
-        warn,
-    )
-    from installer import deps, files, pcloud
+    from installer import common, deps, files, pcloud
     from utils.selftest import run_stack_tests
+
+cfg = common.cfg
+say = common.say
+need_root = common.need_root
+ensure_dir_tree = common.ensure_dir_tree
+preflight_ubuntu = common.preflight_ubuntu
+prompt_core_values = common.prompt_core_values
+pick_and_merge_preset = common.pick_and_merge_preset
+ok = common.ok
+warn = common.warn
+# ``prompt_backup_plan`` was added in newer releases; fall back to a no-op if
+# running against an older checkout that lacks it.
+prompt_backup_plan = getattr(common, "prompt_backup_plan", lambda: None)
 
 
 def main() -> None:
     need_root()
+    say(f"Fetching assets from branch '{BRANCH}'")
 
     say("Starting Paperless-ngx setup wizard...")
     preflight_ubuntu()
@@ -78,11 +80,28 @@ def main() -> None:
     # pCloud
     pcloud.ensure_pcloud_remote_or_menu()
 
+    ensure_dir_tree(cfg)
+    restore_existing_backup_if_present = getattr(
+        files, "restore_existing_backup_if_present", lambda: False
+    )
+    if restore_existing_backup_if_present():
+        files.copy_helper_scripts()
+        if Path(cfg.env_file).exists():
+            for line in Path(cfg.env_file).read_text().splitlines():
+                if line.startswith("CRON_FULL_TIME="):
+                    cfg.cron_full_time = line.split("=", 1)[1].strip()
+                elif line.startswith("CRON_INCR_TIME="):
+                    cfg.cron_incr_time = line.split("=", 1)[1].strip()
+        files.install_cron_backup()
+        files.show_status()
+        return
+
     # Presets and prompts
     pick_and_merge_preset(
         f"https://raw.githubusercontent.com/obidose/obidose-paperless-ngx-bulletproof/{BRANCH}"
     )
     prompt_core_values()
+    prompt_backup_plan()
 
     # Directories and files
     ensure_dir_tree(cfg)

--- a/installer/common.py
+++ b/installer/common.py
@@ -117,7 +117,8 @@ class Config:
     rclone_remote_name: str = os.environ.get("RCLONE_REMOTE_NAME", "pcloud")
     rclone_remote_path: str = os.environ.get("RCLONE_REMOTE_PATH", "backups/paperless/paperless")
     retention_days: str = os.environ.get("RETENTION_DAYS", "30")
-    cron_time: str = os.environ.get("CRON_TIME", "30 3 * * *")
+    cron_full_time: str = os.environ.get("CRON_FULL_TIME", "30 3 * * *")
+    cron_incr_time: str = os.environ.get("CRON_INCR_TIME", "0 * * * *")
 
     env_backup_mode: str = os.environ.get("ENV_BACKUP_MODE", "openssl")
     env_backup_passphrase_file: str = os.environ.get("ENV_BACKUP_PASSPHRASE_FILE", "/root/.paperless_env_pass")
@@ -174,6 +175,39 @@ def prompt_core_values() -> None:
 
     cfg.refresh_paths()
 
+
+def prompt_backup_plan() -> None:
+    print()
+    say("Configure backup schedule")
+    print("Full backups capture everything; incremental backups save changes since the last full.")
+
+    def parse_time(val: str, default: str) -> str:
+        val = val.strip()
+        if not val:
+            return default
+        if " " in val:
+            return val
+        if ":" in val:
+            h, m = val.split(":", 1)
+            if h.isdigit() and m.isdigit():
+                return f"{int(m)} {int(h)} * * *"
+        return default
+
+    def parse_interval(val: str, default: str) -> str:
+        val = val.strip()
+        if not val:
+            return default
+        if " " in val:
+            return val
+        if val.isdigit():
+            n = max(1, int(val))
+            return f"0 */{n} * * *"
+        return default
+
+    full_raw = prompt("When should the full backup run? (HH:MM 24h or cron)", "03:30")
+    incr_raw = prompt("Run incremental backups every how many hours? (number or cron)", "1")
+    cfg.cron_full_time = parse_time(full_raw, cfg.cron_full_time)
+    cfg.cron_incr_time = parse_interval(incr_raw, cfg.cron_incr_time)
 
 
 def pick_and_merge_preset(base: str) -> None:

--- a/modules/backup.py
+++ b/modules/backup.py
@@ -2,12 +2,23 @@
 """Snapshot Paperless-ngx data and upload to an rclone remote."""
 import os
 import sys
-import tarfile
 import tempfile
 import subprocess
 import time
 from pathlib import Path
 from datetime import datetime
+
+
+def list_snapshots() -> list[str]:
+    res = subprocess.run(
+        ["rclone", "lsd", REMOTE], capture_output=True, text=True, check=False
+    )
+    snaps = []
+    for line in res.stdout.splitlines():
+        parts = line.strip().split()
+        if parts:
+            snaps.append(parts[-1].rstrip("/"))
+    return sorted(snaps)
 
 
 def load_env(path: Path) -> None:
@@ -98,13 +109,27 @@ def dump_db(work: Path) -> None:
         warn("Compose file not found; skipping DB dump")
 
 
-def tar_dir(src: Path, name: str, work: Path) -> None:
+def tar_dir(src: Path, name: str, work: Path, mode: str) -> None:
     if not src.exists():
         warn(f"Skip {name}: directory not found at {src}")
         return
     say(f"Archiving {name}…")
-    with tarfile.open(work / f"{name}.tar.gz", "w:gz") as tar:
-        tar.add(src, arcname=name)
+    snarf = work / f"{name}.snar"
+    if mode == "full" and snarf.exists():
+        snarf.unlink()
+    subprocess.run(
+        [
+            "tar",
+            "--listed-incremental",
+            str(snarf),
+            "-czf",
+            str(work / f"{name}.tar.gz"),
+            "-C",
+            str(src.parent),
+            name,
+        ],
+        check=True,
+    )
 
 
 def verify_archives(work: Path) -> bool:
@@ -157,16 +182,27 @@ def test_db_restore(work: Path) -> bool:
 
 
 def main() -> None:
-    retention_class = sys.argv[1] if len(sys.argv) > 1 else "auto"
+    mode = sys.argv[1] if len(sys.argv) > 1 else None
+    if mode not in {"full", "incr"}:
+        die("Usage: backup.py [full|incr]")
     ensure_remote_path(REMOTE)
+    snaps = list_snapshots()
+    parent = snaps[-1] if snaps else ""
+    if mode == "incr" and not snaps:
+        mode = "full"
     snap = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
     work = Path(tempfile.mkdtemp(prefix="paperless-backup."))
-    say(f"Creating snapshot {snap}")
+    if mode == "incr" and parent:
+        subprocess.run(
+            ["rclone", "copy", f"{REMOTE}/{parent}", str(work), "--include", "*.snar"],
+            check=False,
+        )
+    say(f"Creating {mode} snapshot {snap}")
 
     dump_db(work)
-    tar_dir(DIR_MEDIA, "media", work)
-    tar_dir(DIR_DATA, "data", work)
-    tar_dir(DIR_EXPORT, "export", work)
+    tar_dir(DIR_MEDIA, "media", work, mode)
+    tar_dir(DIR_DATA, "data", work, mode)
+    tar_dir(DIR_EXPORT, "export", work, mode)
 
     if ENV_FILE.exists():
         (work / ".env").write_text(ENV_FILE.read_text())
@@ -177,9 +213,10 @@ def main() -> None:
         shutil_path = work / "compose.snapshot.yml"
         shutil_path.write_text(COMPOSE_FILE.read_text())
 
-    (work / "manifest.yaml").write_text(
-        f"mode: full\nretention: {retention_class}\ncreated: {datetime.utcnow().isoformat()}\n"
-    )
+    manifest_lines = [f"mode: {mode}", f"created: {datetime.utcnow().isoformat()}"]
+    if mode == "incr" and parent:
+        manifest_lines.append(f"parent: {parent}")
+    (work / "manifest.yaml").write_text("\n".join(manifest_lines) + "\n")
 
     passed = verify_archives(work) and test_db_restore(work)
     status = "status.ok" if passed else "status.fail"

--- a/modules/restore.py
+++ b/modules/restore.py
@@ -2,7 +2,7 @@
 """Restore Paperless-ngx data from an rclone snapshot."""
 import os
 import sys
-import tarfile
+import shutil
 import tempfile
 import subprocess
 import time
@@ -101,21 +101,40 @@ POSTGRES_USER = os.environ.get("POSTGRES_USER", "paperless")
 REMOTE = f"{RCLONE_REMOTE_NAME}:{RCLONE_REMOTE_PATH}"
 
 
-def list_snapshots() -> list[str]:
+def fetch_snapshots() -> list[tuple[str, str, str]]:
     res = subprocess.run(
         ["rclone", "lsd", REMOTE], capture_output=True, text=True, check=False
     )
-    snaps = []
+    snaps: list[tuple[str, str, str]] = []
     for line in res.stdout.splitlines():
         parts = line.strip().split()
-        if parts:
-            snaps.append(parts[-1].rstrip("/"))
-    return sorted(snaps)
+        if not parts:
+            continue
+        name = parts[-1].rstrip("/")
+        mode = parent = "?"
+        cat = subprocess.run(
+            ["rclone", "cat", f"{REMOTE}/{name}/manifest.yaml"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if cat.returncode == 0:
+            for mline in cat.stdout.splitlines():
+                if ":" in mline:
+                    k, v = mline.split(":", 1)
+                    if k.strip() == "mode":
+                        mode = v.strip()
+                    elif k.strip() == "parent":
+                        parent = v.strip()
+        snaps.append((name, mode, parent))
+    return sorted(snaps, key=lambda x: x[0])
 
 
 def extract_tar(tar_path: Path, dest: Path) -> None:
-    with tarfile.open(tar_path, "r:*") as tar:
-        tar.extractall(path=dest)
+    subprocess.run(
+        ["tar", "--listed-incremental=/dev/null", "-xpf", str(tar_path), "-C", str(dest)],
+        check=True,
+    )
 
 
 def restore_db(dump: Path) -> None:
@@ -189,38 +208,59 @@ def restore_db(dump: Path) -> None:
 
 
 def main() -> None:
-    snaps = list_snapshots()
+    snaps = fetch_snapshots()
     if not snaps:
         die(f"No snapshots found in {REMOTE}")
-    snap = sys.argv[1] if len(sys.argv) > 1 else snaps[-1]
-    if snap not in snaps:
-        die(f"Snapshot {snap} not found")
-    say(f"Restoring snapshot {snap}")
-    tmp = Path(tempfile.mkdtemp(prefix="paperless-restore."))
-    subprocess.run(["rclone", "sync", f"{REMOTE}/{snap}", str(tmp)], check=True)
-
+    names = [n for n, _, _ in snaps]
+    target = sys.argv[1] if len(sys.argv) > 1 else names[-1]
+    if target not in names:
+        die(f"Snapshot {target} not found")
+    meta = {n: (m, p) for n, m, p in snaps}
+    chain = []
+    cur = target
+    while True:
+        chain.append(cur)
+        mode, parent = meta.get(cur, ("full", ""))
+        if mode == "full" or not parent:
+            break
+        cur = parent
+    chain.reverse()
+    say("Restoring chain: " + " -> ".join(chain))
     subprocess.run(["docker", "compose", "-f", str(COMPOSE_FILE), "down"], check=False)
-
-    if (tmp / ".env").exists():
-        (STACK_DIR / ".env").write_text((tmp / ".env").read_text())
-        ok("Restored .env")
-
-    for name in ["data", "media", "export"]:
-        dest = DATA_ROOT / name
-        if dest.exists():
-            subprocess.run(["rm", "-rf", str(dest)], check=False)
-        tarfile_path = next(tmp.glob(f"{name}.tar*"), None)
-        if tarfile_path:
-            extract_tar(tarfile_path, DATA_ROOT)
-
-    dump = next(tmp.glob("postgres.sql*"), None)
-    if dump:
-        restore_db(dump)
-
-    compose_snap = tmp / "compose.snapshot.yml"
-    if compose_snap.exists():
-        compose_snap.replace(COMPOSE_FILE)
-
+    dump_dir = Path(tempfile.mkdtemp(prefix="paperless-restore-dump."))
+    final_dump: Path | None = None
+    first = True
+    for snap in chain:
+        tmp = Path(tempfile.mkdtemp(prefix="paperless-restore."))
+        subprocess.run(["rclone", "sync", f"{REMOTE}/{snap}", str(tmp)], check=True)
+        if first:
+            if (tmp / ".env").exists():
+                (STACK_DIR / ".env").write_text((tmp / ".env").read_text())
+                ok("Restored .env")
+            for name in ["data", "media", "export"]:
+                dest = DATA_ROOT / name
+                if dest.exists():
+                    subprocess.run(["rm", "-rf", str(dest)], check=False)
+                tarfile_path = next(tmp.glob(f"{name}.tar*"), None)
+                if tarfile_path:
+                    extract_tar(tarfile_path, DATA_ROOT)
+            compose_snap = tmp / "compose.snapshot.yml"
+            if compose_snap.exists():
+                compose_snap.replace(COMPOSE_FILE)
+            first = False
+        else:
+            for name in ["data", "media", "export"]:
+                tarfile_path = next(tmp.glob(f"{name}.tar*"), None)
+                if tarfile_path:
+                    extract_tar(tarfile_path, DATA_ROOT)
+        dump = next(tmp.glob("postgres.sql*"), None)
+        if dump:
+            final_dump = dump_dir / dump.name
+            shutil.move(str(dump), final_dump)
+        shutil.rmtree(tmp)
+    if final_dump:
+        restore_db(final_dump)
+    shutil.rmtree(dump_dir, ignore_errors=True)
     subprocess.run(["docker", "compose", "-f", str(COMPOSE_FILE), "up", "-d"], check=False)
     if run_stack_tests(COMPOSE_FILE, ENV_FILE):
         ok("Restore complete")
@@ -234,3 +274,5 @@ if __name__ == "__main__":
     finally:
         if 'tmp' in locals() and Path(tmp).exists():
             subprocess.run(["rm", "-rf", str(tmp)])
+        if 'dump_dir' in locals() and Path(dump_dir).exists():
+            subprocess.run(["rm", "-rf", str(dump_dir)])

--- a/tools/bulletproof.py
+++ b/tools/bulletproof.py
@@ -55,6 +55,8 @@ RCLONE_REMOTE_PATH = os.environ.get(
     "RCLONE_REMOTE_PATH", f"backups/paperless/{INSTANCE_NAME}"
 )
 REMOTE = f"{RCLONE_REMOTE_NAME}:{RCLONE_REMOTE_PATH}"
+CRON_FULL_TIME = os.environ.get("CRON_FULL_TIME", "30 3 * * *")
+CRON_INCR_TIME = os.environ.get("CRON_INCR_TIME", "0 * * * *")
 
 
 def dc(*args: str) -> list[str]:
@@ -62,14 +64,6 @@ def dc(*args: str) -> list[str]:
 
 
 def fetch_snapshots() -> list[tuple[str, str, str]]:
-    """Return a list of available snapshots with basic metadata.
-
-    Each entry is a tuple ``(name, mode, retention)`` where ``mode`` is the
-    backup type (e.g. ``full`` or ``incr``) and ``retention`` is the retention
-    class recorded in the snapshot's ``manifest.yaml``. If the manifest is
-    missing or cannot be read the fields default to ``?``.
-    """
-
     try:
         res = subprocess.run(
             ["rclone", "lsd", REMOTE], capture_output=True, text=True, check=False
@@ -83,7 +77,7 @@ def fetch_snapshots() -> list[tuple[str, str, str]]:
         if not parts:
             continue
         name = parts[-1]
-        mode = retention = "?"
+        mode = parent = "?"
         cat = subprocess.run(
             ["rclone", "cat", f"{REMOTE}/{name}/manifest.yaml"],
             capture_output=True,
@@ -98,9 +92,9 @@ def fetch_snapshots() -> list[tuple[str, str, str]]:
                     v = v.strip()
                     if k == "mode":
                         mode = v
-                    elif k == "retention":
-                        retention = v
-        snaps.append((name, mode, retention))
+                    elif k == "parent":
+                        parent = v
+        snaps.append((name, mode, parent))
     return sorted(snaps, key=lambda x: x[0])
 
 
@@ -109,18 +103,30 @@ def cmd_backup(args: argparse.Namespace) -> None:
     if not script.exists():
         die(f"Backup script not found at {script}")
     run = [str(script)]
-    if args.retention:
-        run.append(args.retention)
+    if args.mode:
+        run.append(args.mode)
     subprocess.run(run, check=True)
 
 
-def cmd_list(_: argparse.Namespace) -> None:
+def cmd_snapshots(args: argparse.Namespace) -> None:
     snaps = fetch_snapshots()
     if not snaps:
         warn("No snapshots found")
         return
-    for name, mode, retention in snaps:
-        print(f"{name}\t{mode}\t{retention}")
+
+    print(f"{'#':>3} {'NAME':<32} {'MODE':<8} PARENT")
+    for idx, (name, mode, parent) in enumerate(snaps, 1):
+        parent_disp = parent if mode == "incr" else "-"
+        print(f"{idx:>3} {name:<32} {mode:<8} {parent_disp}")
+
+    snap = args.snapshot
+    if snap is None and sys.stdin.isatty():
+        snap = input("Snapshot number for manifest (blank=exit): ").strip() or None
+    if not snap:
+        return
+    if snap.isdigit() and 1 <= int(snap) <= len(snaps):
+        snap = snaps[int(snap) - 1][0]
+    subprocess.run(["rclone", "cat", f"{REMOTE}/{snap}/manifest.yaml"], check=True)
 
 
 def cmd_restore(args: argparse.Namespace) -> None:
@@ -133,31 +139,17 @@ def cmd_restore(args: argparse.Namespace) -> None:
         snaps = fetch_snapshots()
         if snaps:
             print("Available snapshots:")
-            for name, mode, retention in snaps:
-                print(f"- {name} ({mode}, {retention})")
+            for name, mode, parent in snaps:
+                detail = f"{mode}" if mode != "incr" else f"{mode}<-{parent}"
+                print(f"- {name} ({detail})")
     else:
         run.append(snap)
     subprocess.run(run, check=True)
 
 
-def cmd_manifest(args: argparse.Namespace) -> None:
-    snap = args.snapshot
-    if not snap:
-        res = subprocess.run(
-            ["rclone", "lsd", REMOTE], capture_output=True, text=True, check=True
-        )
-        snaps = [line.split()[-1] for line in res.stdout.strip().splitlines() if line]
-        if not snaps:
-            die("No snapshots found")
-        snap = snaps[-1]
-    subprocess.run(
-        ["rclone", "cat", f"{REMOTE}/{snap}/manifest.yaml"], check=True
-    )
-
-
 def cmd_upgrade(_: argparse.Namespace) -> None:
     say("Running backup before upgrade")
-    cmd_backup(argparse.Namespace(retention="auto"))
+    cmd_backup(argparse.Namespace(mode="full"))
     say("Pulling images")
     subprocess.run(dc("pull"), check=False)
     say("Recreating containers")
@@ -194,29 +186,126 @@ def cmd_doctor(_: argparse.Namespace) -> None:
     subprocess.run(["docker", "info"], check=False)
 
 
+def install_cron(full: str, incr: str) -> None:
+    full_line = (
+        f"{full} root {STACK_DIR}/backup.py full >> {STACK_DIR}/backup.log 2>&1"
+    )
+    incr_line = (
+        f"{incr} root {STACK_DIR}/backup.py incr >> {STACK_DIR}/backup.log 2>&1"
+    )
+    crontab = Path("/etc/crontab")
+    lines = [
+        l
+        for l in (crontab.read_text().splitlines() if crontab.exists() else [])
+        if f"{STACK_DIR}/backup.py" not in l
+    ]
+    lines.extend([full_line, incr_line])
+    crontab.write_text("\n".join(lines) + "\n")
+    if ENV_FILE.exists():
+        env_lines = [
+            l
+            for l in ENV_FILE.read_text().splitlines()
+            if not l.startswith("CRON_FULL_TIME=") and not l.startswith("CRON_INCR_TIME=")
+        ]
+        env_lines.append(f"CRON_FULL_TIME={full}")
+        env_lines.append(f"CRON_INCR_TIME={incr}")
+        ENV_FILE.write_text("\n".join(env_lines) + "\n")
+    subprocess.run(["systemctl", "restart", "cron"], check=False)
+    global CRON_FULL_TIME, CRON_INCR_TIME
+    CRON_FULL_TIME = full
+    CRON_INCR_TIME = incr
+    ok("Backup schedule updated")
+
+
+def parse_time(val: str, current: str) -> str:
+    val = val.strip()
+    if not val:
+        return current
+    if " " in val:
+        return val
+    if ":" in val:
+        h, m = val.split(":", 1)
+        if h.isdigit() and m.isdigit():
+            return f"{int(m)} {int(h)} * * *"
+    return current
+
+
+def parse_interval(val: str, current: str) -> str:
+    val = val.strip()
+    if not val:
+        return current
+    if " " in val:
+        return val
+    if val.isdigit():
+        n = max(1, int(val))
+        return f"0 */{n} * * *"
+    return current
+
+
+def cmd_schedule(args: argparse.Namespace) -> None:
+    print("Full backups capture everything; incremental backups store only changes.")
+    full_prompt = f"Time for daily full backup (HH:MM or cron) [{CRON_FULL_TIME}]: "
+    incr_prompt = f"Incremental backup frequency (hours or cron) [{CRON_INCR_TIME}]: "
+    full_in = args.full or input(full_prompt).strip()
+    incr_in = args.incr or input(incr_prompt).strip()
+    full = parse_time(full_in, CRON_FULL_TIME)
+    incr = parse_interval(incr_in, CRON_INCR_TIME)
+    install_cron(full, incr)
+
+
 def menu() -> None:
     """Interactive menu for easier use."""
     while True:
-        print("Bulletproof helper")
+        snaps = fetch_snapshots()
+        latest = snaps[-1][0] if snaps else "none"
+        print(f"{COLOR_BLUE}=== Bulletproof ({INSTANCE_NAME}) ==={COLOR_OFF}")
+        print(f"Remote: {REMOTE}")
+        print(f"Snapshots: {len(snaps)} (latest: {latest})")
+        def desc(full: str, incr: str) -> str:
+            try:
+                m, h, dom, mon, dow = full.split()
+                if dom == mon == dow == "*":
+                    full_txt = f"daily at {int(h):02d}:{int(m):02d}"
+                else:
+                    full_txt = full
+            except Exception:
+                full_txt = full
+            try:
+                parts = incr.split()
+                if parts[0] == "0" and parts[1].startswith("*/"):
+                    hrs = parts[1][2:]
+                    incr_txt = f"every {int(hrs)}h"
+                else:
+                    incr_txt = incr
+            except Exception:
+                incr_txt = incr
+            return f"full {full_txt}, incr {incr_txt}"
+
+        print(f"Schedule: {desc(CRON_FULL_TIME, CRON_INCR_TIME)}\n")
         print("1) Backup")
-        print("2) List snapshots")
+        print("2) Snapshots")
         print("3) Restore snapshot")
-        print("4) Show manifest")
-        print("5) Upgrade")
-        print("6) Status")
-        print("7) Logs")
-        print("8) Doctor")
+        print("4) Upgrade")
+        print("5) Status")
+        print("6) Logs")
+        print("7) Doctor")
+        print("8) Backup schedule")
         print("9) Quit")
         choice = input("Choose [1-9]: ").strip()
         if choice == "1":
-            ret = input("Retention (daily|weekly|monthly|auto) [auto]: ").strip() or "auto"
-            cmd_backup(argparse.Namespace(retention=ret))
+            mode_in = input("Full or Incremental? [incr]: ").strip().lower()
+            if mode_in.startswith("f"):
+                mode = "full"
+            else:
+                mode = "incr"
+            cmd_backup(argparse.Namespace(mode=mode))
         elif choice == "2":
-            cmd_list(argparse.Namespace())
+            cmd_snapshots(argparse.Namespace(snapshot=None))
         elif choice == "3":
             snaps = fetch_snapshots()
-            for idx, (name, mode, retention) in enumerate(snaps, 1):
-                print(f"{idx}) {name} ({mode}, {retention})")
+            for idx, (name, mode, parent) in enumerate(snaps, 1):
+                detail = f"{mode}" if mode != "incr" else f"{mode}<-{parent}"
+                print(f"{idx}) {name} ({detail})")
             choice_snap = input("Snapshot number or name (blank=latest): ").strip()
             if choice_snap.isdigit():
                 idx = int(choice_snap)
@@ -225,17 +314,16 @@ def menu() -> None:
                 snap = choice_snap or None
             cmd_restore(argparse.Namespace(snapshot=snap))
         elif choice == "4":
-            snap = input("Snapshot (blank=latest): ").strip() or None
-            cmd_manifest(argparse.Namespace(snapshot=snap))
-        elif choice == "5":
             cmd_upgrade(argparse.Namespace())
-        elif choice == "6":
+        elif choice == "5":
             cmd_status(argparse.Namespace())
-        elif choice == "7":
+        elif choice == "6":
             svc = input("Service (blank=all): ").strip() or None
             cmd_logs(argparse.Namespace(service=svc))
-        elif choice == "8":
+        elif choice == "7":
             cmd_doctor(argparse.Namespace())
+        elif choice == "8":
+            cmd_schedule(argparse.Namespace(full=None, incr=None))
         elif choice == "9":
             break
         else:
@@ -246,19 +334,20 @@ parser = argparse.ArgumentParser(description="Paperless-ngx bulletproof helper")
 sub = parser.add_subparsers(dest="command")
 
 p = sub.add_parser("backup", help="run backup script")
-p.add_argument("retention", nargs="?", help="daily|weekly|monthly|auto")
+p.add_argument("mode", nargs="?", choices=["full", "incr"], help="full|incr")
 p.set_defaults(func=cmd_backup)
 
-p = sub.add_parser("list", help="list snapshots")
-p.set_defaults(func=cmd_list)
+p = sub.add_parser("snapshots", help="list snapshots and optionally show a manifest")
+p.add_argument(
+    "snapshot",
+    nargs="?",
+    help="snapshot name or number to show manifest",
+)
+p.set_defaults(func=cmd_snapshots)
 
 p = sub.add_parser("restore", help="restore snapshot")
 p.add_argument("snapshot", nargs="?")
 p.set_defaults(func=cmd_restore)
-
-p = sub.add_parser("manifest", help="show snapshot manifest")
-p.add_argument("snapshot", nargs="?")
-p.set_defaults(func=cmd_manifest)
 
 p = sub.add_parser("upgrade", help="backup then pull images and up -d")
 p.set_defaults(func=cmd_upgrade)
@@ -272,6 +361,11 @@ p.set_defaults(func=cmd_logs)
 
 p = sub.add_parser("doctor", help="basic checks")
 p.set_defaults(func=cmd_doctor)
+
+p = sub.add_parser("schedule", help="configure backup schedule")
+p.add_argument("--full", help="time for daily full backup (HH:MM or cron)")
+p.add_argument("--incr", help="incremental frequency (hours or cron)")
+p.set_defaults(func=cmd_schedule)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Prompt to restore from existing snapshots and allow choosing which to apply before continuing installation
- Configure daily full and hourly incremental backup cron jobs, with CLI support to adjust both schedules
- Require explicit full or incremental mode when running backups, dropping the old auto rotation
- Preserve database dumps during snapshot restores by moving them out of temporary directories before cleanup
- Install Bulletproof CLI even when restoration ends the install early
- Improve backup schedule prompts with human-friendly HH:MM and hourly inputs, showing the schedule in the CLI banner
- Consolidate snapshot listing and manifest viewing, allowing interactive manifest selection by number

## Testing
- `python -m py_compile modules/backup.py modules/restore.py tools/bulletproof.py install.py installer/common.py installer/files.py`


------
https://chatgpt.com/codex/tasks/task_e_68b80f2b160c8326ba28508d5d034a1a