### PR TITLE
Handle installer input when run via pipe

### DIFF
--- a/installer/common.py
+++ b/installer/common.py
@@ -5,8 +5,25 @@ import secrets
 from dataclasses import dataclass
 from pathlib import Path
 
+
+def _tty_path() -> str:
+    """Best-effort path to a readable/writable TTY."""
+    for key in ("TTY", "SSH_TTY", "SUDO_TTY"):
+        path = os.environ.get(key)
+        if path:
+            return path
+    for fd in (0, 1, 2):
+        try:
+            return os.ttyname(fd)
+        except OSError:
+            continue
+    return "/dev/tty"
+
+
 try:
-    TTY = open("/dev/tty")
+    TTY = open(_tty_path(), "r+")
+    if not sys.stdin.isatty():
+        sys.stdin = sys.stdout = sys.stderr = TTY
 except OSError:
     TTY = None
 


### PR DESCRIPTION
## Summary
- Open a usable TTY even when stdin is not a terminal so the installer works with `curl ... | sudo python3 -`

## Testing
- `python -m py_compile install.py installer/common.py`


------
https://chatgpt.com/codex/tasks/task_e_68bad941e2f4832695f53a52c86e5355